### PR TITLE
feat: add a new snippet custom_post_install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,7 @@
   loop:
     - create_automation_user
     - partition
+    - custom_post_install
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -32,11 +32,14 @@
   ansible.builtin.lineinfile:
     path: /var/lib/cobbler/scripts/preseed_late_default
     insertbefore: 'autoinstall_done'
-    line: $SNIPPET('create_automation_user')
+    line: "$SNIPPET('{{ item }}')"
     create: true
     owner: root
     group: root
     mode: '0644'
+  loop:
+    - create_automation_user
+    - custom_post_install
 
 - name: Configure Cobbler profiles
   cobbler_profile:

--- a/templates/snippets/custom_post_install.j2
+++ b/templates/snippets/custom_post_install.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+{% if cobbler_custom_post_install is defined %}
+{{ cobbler_custom_post_install }}
+{% else %}
+# Define your custom script with variable `cobbler_custom_post_install`.
+{% endif %}


### PR DESCRIPTION
This will install a new snippet that will be executed during the post
installation process, in the script preseed_late_default. By default,
the snippet is empty. One can define a custom script with the variable
`cobbler_custom_post_install`.

It is also possible to override this snippet with a per profile, distro
or system snippet.