### PR TITLE
fix: configure $kernel_options_post in debian seed

### DIFF
--- a/templates/templates/debian.seed.j2
+++ b/templates/templates/debian.seed.j2
@@ -265,7 +265,7 @@ d-i grub-installer/bootdev  string default
 # Use the following option to add additional boot parameters for the
 # installed system (if supported by the bootloader installer).
 # Note: options passed to the installer will be added automatically.
-#d-i debian-installer/add-kernel-opts string nousb
+d-i debian-installer/add-kernel-opts string $kernel_options_post
 
 ### Finishing up the installation
 # During installations from serial console, the regular virtual consoles


### PR DESCRIPTION
Cobbler allows to define kernel options to configure during
post-installation. Make sure the preseed file will add these options.