### PR TITLE
feat: Add autoinstall meta variable packages

### DIFF
--- a/tasks/distros.yml
+++ b/tasks/distros.yml
@@ -71,8 +71,8 @@
   loop: "{{ cobbler_distros | subelements('snippets', skip_missing=True) }}"
 
 - name: Copy per_distro snippets
-  ansible.builtin.copy:
-    content: "{{ item.1.content }}"
+  ansible.builtin.template:
+    src: per_snippet.j2
     dest: "/var/lib/cobbler/snippets/per_distro/{{ item.1.name }}/{{ item.0.name }}"
     owner: root
     group: root

--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -11,8 +11,8 @@
     - rhel.ks
 
 - name: Copy custom autoinstall templates
-  ansible.builtin.copy:
-    content: "{{ item.content }}"
+  ansible.builtin.template:
+    src: templates.j2
     dest: "/var/lib/cobbler/templates/{{ item.name }}"
     owner: root
     group: root
@@ -69,8 +69,8 @@
     label: "Create directory /var/lib/cobbler/snippets/per_profile/{{ item.1.name }}"
 
 - name: Copy per_profile snippets
-  ansible.builtin.copy:
-    content: "{{ item.1.content }}"
+  ansible.builtin.template:
+    src: per_snippet.j2
     owner: root
     group: root
     mode: '0644'

--- a/tasks/repositories-Debian.yml
+++ b/tasks/repositories-Debian.yml
@@ -9,8 +9,8 @@
     keyring: /etc/apt/trusted.gpg.d/cobbler.gpg
 
 - name: Configure Cobbler repository
-  ansible.builtin.copy:
-    content: "{{ cobbler_apt_repository }}\n"
+  ansible.builtin.template:
+    src: apt_repository.j2
     dest: /etc/apt/sources.list.d/cobbler.list
     owner: root
     group: root

--- a/tasks/systems.yml
+++ b/tasks/systems.yml
@@ -9,8 +9,8 @@
   loop: "{{ cobbler_systems | subelements('snippets', skip_missing=True) }}"
 
 - name: Copy per_system snippets
-  ansible.builtin.copy:
-    content: "{{ item.1.content }}"
+  ansible.builtin.template:
+    src: per_snippet.j2
     dest: "/var/lib/cobbler/snippets/per_system/{{ item.1.name }}/{{ item.0.name }}"
     owner: root
     group: root

--- a/templates/apt_repository.j2
+++ b/templates/apt_repository.j2
@@ -1,0 +1,1 @@
+{{ cobbler_apt_repository }}

--- a/templates/per_snippet.j2
+++ b/templates/per_snippet.j2
@@ -1,0 +1,1 @@
+{{ item.1.content }}

--- a/templates/snippets/custom_post_install.j2
+++ b/templates/snippets/custom_post_install.j2
@@ -3,4 +3,7 @@
 {{ cobbler_custom_post_install }}
 {% else %}
 # Define your custom script with variable `cobbler_custom_post_install`.
+#if $getVar('packages', '') != ''
+sudo apt install -y $packages
+#end if
 {% endif %}

--- a/templates/templates.j2
+++ b/templates/templates.j2
@@ -1,0 +1,1 @@
+{{ item.content }}

--- a/templates/templates/rhel.ks.j2
+++ b/templates/templates/rhel.ks.j2
@@ -50,6 +50,9 @@ $SNIPPET('pre_anamon')
 %packages
 openssh-server
 sudo
+#if $getVar('packages', '') != ''
+$packages
+#end if
 %end
 
 %post --nochroot


### PR DESCRIPTION
The new autoinstall meta variable `packages` allows to install additional packages during the provisioning of the system.

For RHEL-like, inject the packages in the template file. The list of packages should include one package per line. For this, define the list of packages with YAML block scalar style literal (`|`).

```
  - name: profileA
    properties:
      distro: almalinux-8
      autoinstall_meta:
        packages: |
          cloud-init
          qemu-guest-agent
```

For Debian-like, it's a bit trickier to add packages to a single line, considering conditions already exists to select a list of base packages. Instead, install the packages with apt during post-installation stage.

The list of packages should be provided as a single line. For this, define the list with YAML block scalar style folded (`>`).

```
  - name: profileB
    properties:
      distro: debian-11
      autoinstall_meta:
        packages: >
          cloud-init
          qemu-guest-agent
```

Note: If one should define their own script with `custom_post_install`, they would have to import the logic to install additional package in their new script.