### PR TITLE
chore: Make ansible-lint happy

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+  - no-changed-when

--- a/tasks/modules.yml
+++ b/tasks/modules.yml
@@ -1,5 +1,6 @@
 ---
 - name: Configure Dnsmasq to act as a DHCP and DNS server
+  when: cobbler_dnsmasq_module
   block:
     - name: Install dnsmasq
       ansible.builtin.package:
@@ -45,4 +46,3 @@
         mode: '0600'
       loop: ['dns', 'dhcp']
       notify: Restart cobbler
-  when: cobbler_dnsmasq_module

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = ansible{4,5}
+envlist = ansible{6,7}
 skipsdist = true
 
 [testenv]
@@ -11,9 +11,10 @@ passenv =
     PY_COLORS
     ANSIBLE_FORCE_COLOR
 deps =
-    ansible4: ansible>=4.0,<5.0
-    ansible5: ansible>=5.0,<6.0
+    ansible6: ansible>=6.0,<7.0
+    ansible7: ansible>=7.0,<8.0
     ansible-lint
-    molecule[docker]
+    molecule
+    molecule-docker
 commands =
     molecule test


### PR DESCRIPTION
New release of ansible-lint enforced some rules. Agreed on the `key-order[task]`, but skip the `no-changed-when` that would need further work. This may be enabled later.