### PR TITLE
feat: Add new snippet to configure apt setup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,9 +59,10 @@
     group: root
     mode: '0644'
   loop:
+    - apt_setup
     - create_automation_user
-    - partition
     - custom_post_install
+    - partition
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/templates/snippets/apt_setup.j2
+++ b/templates/snippets/apt_setup.j2
@@ -1,0 +1,41 @@
+# {{ ansible_managed }}
+# Choose, if you want to scan additional installation media
+# (default: false).
+d-i apt-setup/cdrom/set-first boolean false
+# You can choose to install non-free and contrib software.
+#d-i apt-setup/non-free boolean true
+#d-i apt-setup/contrib boolean true
+# Uncomment the following line, if you don't want to have the sources.list
+# entry for a DVD/BD installation image active in the installed system
+# (entries for netinst or CD images will be disabled anyway, regardless of
+# this setting).
+#d-i apt-setup/disable-cdrom-entries boolean true
+# Uncomment this if you don't want to use a network mirror.
+#d-i apt-setup/use_mirror boolean false
+# Select which update services to use; define the mirrors to be used.
+# Values shown below are the normal defaults.
+#d-i apt-setup/services-select multiselect security, updates
+#d-i apt-setup/security_host string security.debian.org
+
+# Additional repositories, local[0-9] available
+#d-i apt-setup/local0/repository string \
+#       http://local.server/debian stable main
+#d-i apt-setup/local0/comment string local server
+# Enable deb-src lines
+#d-i apt-setup/local0/source boolean true
+# URL to the public key of the local repository; you must provide a key or
+# apt will complain about the unauthenticated repository and so the
+# sources.list line will be left commented out.
+#d-i apt-setup/local0/key string http://local.server/key
+# If the provided key file ends in ".asc" the key file needs to be an
+# ASCII-armoured PGP key, if it ends in ".gpg" it needs to use the
+# "GPG key public keyring" format, the "keybox database" format is
+# currently not supported.
+
+# By default the installer requires that repositories be authenticated
+# using a known gpg key. This setting can be used to disable that
+# authentication. Warning: Insecure, not recommended.
+#d-i debian-installer/allow_unauthenticated boolean true
+
+# Uncomment this to add multiarch configuration for i386
+#d-i apt-setup/multiarch string i386

--- a/templates/templates/debian.seed.j2
+++ b/templates/templates/debian.seed.j2
@@ -169,46 +169,7 @@ $SNIPPET('partition')
 #d-i base-installer/kernel/image string linux-image-686
 
 ### Apt setup
-# Choose, if you want to scan additional installation media
-# (default: false).
-d-i apt-setup/cdrom/set-first boolean false
-# You can choose to install non-free and contrib software.
-#d-i apt-setup/non-free boolean true
-#d-i apt-setup/contrib boolean true
-# Uncomment the following line, if you don't want to have the sources.list
-# entry for a DVD/BD installation image active in the installed system
-# (entries for netinst or CD images will be disabled anyway, regardless of
-# this setting).
-#d-i apt-setup/disable-cdrom-entries boolean true
-# Uncomment this if you don't want to use a network mirror.
-#d-i apt-setup/use_mirror boolean false
-# Select which update services to use; define the mirrors to be used.
-# Values shown below are the normal defaults.
-#d-i apt-setup/services-select multiselect security, updates
-#d-i apt-setup/security_host string security.debian.org
-
-# Additional repositories, local[0-9] available
-#d-i apt-setup/local0/repository string \
-#       http://local.server/debian stable main
-#d-i apt-setup/local0/comment string local server
-# Enable deb-src lines
-#d-i apt-setup/local0/source boolean true
-# URL to the public key of the local repository; you must provide a key or
-# apt will complain about the unauthenticated repository and so the
-# sources.list line will be left commented out.
-#d-i apt-setup/local0/key string http://local.server/key
-# If the provided key file ends in ".asc" the key file needs to be an
-# ASCII-armoured PGP key, if it ends in ".gpg" it needs to use the
-# "GPG key public keyring" format, the "keybox database" format is
-# currently not supported.
-
-# By default the installer requires that repositories be authenticated
-# using a known gpg key. This setting can be used to disable that
-# authentication. Warning: Insecure, not recommended.
-#d-i debian-installer/allow_unauthenticated boolean true
-
-# Uncomment this to add multiarch configuration for i386
-#d-i apt-setup/multiarch string i386
+$SNIPPET('apt_setup')
 
 
 ### Package selection


### PR DESCRIPTION
Use the snippet in the template debian.seed. This opens the door to define apt setup configuration snippets per profile or per host for this template.