### PR TITLE
refactor: Configure per_ snippets in a single place

### DIFF
--- a/tasks/distros.yml
+++ b/tasks/distros.yml
@@ -61,20 +61,9 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Create per_distro snippets directories
-  ansible.builtin.file:
-    path: "/var/lib/cobbler/snippets/per_distro/{{ item.1.name }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  loop: "{{ cobbler_distros | subelements('snippets', skip_missing=True) }}"
-
-- name: Copy per_distro snippets
-  ansible.builtin.template:
-    src: per_snippet.j2
-    dest: "/var/lib/cobbler/snippets/per_distro/{{ item.1.name }}/{{ item.0.name }}"
-    owner: root
-    group: root
-    mode: '0644'
-  loop: "{{ cobbler_distros | subelements('snippets', skip_missing=True) }}"
+- name: Configure per_distro snippets
+  vars:
+    _snippet_type: per_distro
+    _snippet_conf: "{{ cobbler_distros | subelements('snippets', skip_missing=True) }}"
+  ansible.builtin.include_tasks:
+    file: "snippets.yml"

--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -57,24 +57,9 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Create per_profile snippets directories
-  ansible.builtin.file:
-    path: "/var/lib/cobbler/snippets/per_profile/{{ item.1.name }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  loop: "{{ cobbler_profiles | subelements('snippets', skip_missing=True) }}"
-  loop_control:
-    label: "Create directory /var/lib/cobbler/snippets/per_profile/{{ item.1.name }}"
-
-- name: Copy per_profile snippets
-  ansible.builtin.template:
-    src: per_snippet.j2
-    owner: root
-    group: root
-    mode: '0644'
-    dest: "/var/lib/cobbler/snippets/per_profile/{{ item.1.name }}/{{ item.0.name }}"
-  loop: "{{ cobbler_profiles | subelements('snippets', skip_missing=True) }}"
-  loop_control:
-    label: "Install snippet /var/lib/cobbler/snippets/per_profile/{{ item.1.name }}/{{ item.0.name }}"
+- name: Configure per_profile snippets
+  vars:
+    _snippet_type: per_profile
+    _snippet_conf: "{{ cobbler_profiles | subelements('snippets', skip_missing=True) }}"
+  ansible.builtin.include_tasks:
+    file: "snippets.yml"

--- a/tasks/snippets.yml
+++ b/tasks/snippets.yml
@@ -1,0 +1,22 @@
+---
+- name: "Create snippets directories {{ _snippet_type }}"
+  ansible.builtin.file:
+    path: "/var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  loop: "{{ _snippet_conf }}"
+  loop_control:
+    label: "Create directory /var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}"
+
+- name: "Copy snippets {{ _snippet_type }}"
+  ansible.builtin.template:
+    src: per_snippet.j2
+    owner: root
+    group: root
+    mode: '0644'
+    dest: "/var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/{{ item.0.name }}"
+  loop: "{{ _snippet_conf }}"
+  loop_control:
+    label: "Install snippet /var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/{{ item.0.name }}"

--- a/tasks/systems.yml
+++ b/tasks/systems.yml
@@ -1,18 +1,7 @@
 ---
-- name: Create per_system snippets directories
-  ansible.builtin.file:
-    path: "/var/lib/cobbler/snippets/per_system/{{ item.1.name }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  loop: "{{ cobbler_systems | subelements('snippets', skip_missing=True) }}"
-
-- name: Copy per_system snippets
-  ansible.builtin.template:
-    src: per_snippet.j2
-    dest: "/var/lib/cobbler/snippets/per_system/{{ item.1.name }}/{{ item.0.name }}"
-    owner: root
-    group: root
-    mode: '0644'
-  loop: "{{ cobbler_systems | subelements('snippets', skip_missing=True) }}"
+- name: Configure per_system snippets
+  vars:
+    _snippet_type: per_system
+    _snippet_conf: "{{ cobbler_systems | subelements('snippets', skip_missing=True) }}"
+  ansible.builtin.include_tasks:
+    file: "snippets.yml"


### PR DESCRIPTION
The logic to configure per_system, per_profile and per_distro snippets is similar. Use a single task file with parameters `_snippet_type` to define the type of the snippet (system/profile/distro) and `_snippet_conf` to define the snippets configuration.