### PR TITLE
break: Remove unmanaged snippets

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,3 +94,6 @@ cobbler_dnsmasq_module: false
 # Each item of the list must be a tuple [ option id, option value ].
 # cobbler_dnsmasq_dhcp_options:
 #   - [ 3, '192.168.0.1' ]  # To configure the router
+
+# Remove any unmanaged snippet in per_{system,profile,distro}
+cobbler_remove_unmanaged_snippets: true

--- a/tasks/snippets.yml
+++ b/tasks/snippets.yml
@@ -20,3 +20,33 @@
   loop: "{{ _snippet_conf }}"
   loop_control:
     label: "Install snippet /var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/{{ item.0.name }}"
+
+- name: Remove unmanaged snippets
+  when: cobbler_remove_unmanaged_snippets
+  block:
+    - name: "Define lists of managed snippets {{ _snippet_type }}"
+      ansible.builtin.set_fact:
+        _managed_snippets: "{{ (_managed_snippets | default([])) + ['/var/lib/cobbler/snippets/' + _snippet_type + '/' + item.1.name + '/' + item.0.name] }}"
+      loop: "{{ _snippet_conf }}"
+      loop_control:
+        label: "Add /var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/{{ item.0.name }} to _managed_snippets"
+
+    - name: "Find existing snippets {{ _snippet_type }}"
+      ansible.builtin.find:
+        paths: "/var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/"
+        file_type: file
+      loop: "{{ _snippet_conf }}"
+      loop_control:
+        label: "List snippets in /var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/"
+      register: _find_snippets
+
+    - name: "Define list of existing snippets {{ _snippet_type }}"
+      ansible.builtin.set_fact:
+        _existing_snippets: "{{ _find_snippets | community.general.json_query('results[*].files[*].path') | flatten | unique }}"
+
+    - name: "Remove unmanaged snippets {{ _snippet_type }}"
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ _existing_snippets }}"
+      when: item not in _managed_snippets


### PR DESCRIPTION
When a snippet is removed from the inventory, it should be removed from the Cobbler server as well. This is a breaking change.

It is possible to keep unmanaged snippets by setting `cobbler_remove_unmanaged_snippets: false`.

Closes: #12