### PR TITLE
fix: Do not search existing snippets by name

### DIFF
--- a/tasks/snippets.yml
+++ b/tasks/snippets.yml
@@ -33,16 +33,14 @@
 
     - name: "Find existing snippets {{ _snippet_type }}"
       ansible.builtin.find:
-        paths: "/var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/"
+        paths: "/var/lib/cobbler/snippets/{{ _snippet_type }}/"
         file_type: file
-      loop: "{{ _snippet_conf }}"
-      loop_control:
-        label: "List snippets in /var/lib/cobbler/snippets/{{ _snippet_type }}/{{ item.1.name }}/"
+        recurse: true
       register: _find_snippets
 
     - name: "Define list of existing snippets {{ _snippet_type }}"
       ansible.builtin.set_fact:
-        _existing_snippets: "{{ _find_snippets | community.general.json_query('results[*].files[*].path') | flatten | unique }}"
+        _existing_snippets: "{{ _find_snippets | community.general.json_query('files[*].path') | flatten | unique }}"
 
     - name: "Remove unmanaged snippets {{ _snippet_type }}"
       ansible.builtin.file:


### PR DESCRIPTION
When a snippet name is removed and does not exist anymore, it won't be included in `_snippet_conf`, so it won't be removed.

Recursively search the snippets by type instead. Any snippet that does not exist in the inventory will be removed.