### PR TITLE
ci: molecule docker plugins changed again

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install packages
-        run: pip install ansible-lint
+        run: pip install 'ansible-lint<6.17.0'
 
       - name: Run ansible linter
         run: ansible-lint

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ deps =
     ansible7: ansible>=7.0,<8.0
     ansible-lint
     molecule
-    molecule-docker
+    molecule-plugins[docker]
 commands =
     molecule test

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
 deps =
     ansible6: ansible>=6.0,<7.0
     ansible7: ansible>=7.0,<8.0
-    ansible-lint
+    ansible-lint<6.17.0
     molecule
     molecule-plugins[docker]
 commands =


### PR DESCRIPTION
The name is now `molecule-plugins[docker]`.