### PR TITLE
ci: Pin rich<13.4.0

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install packages
-        run: pip install 'ansible-lint<6.17.0'
+        run: pip install 'ansible-lint<6.17.0' 'rich<13.4.0'
 
       - name: Run ansible linter
         run: ansible-lint


### PR DESCRIPTION
The new release rich 13.4.0 breaks ansible-lint. See https://github.com/mila-iqia/ansible-role-cobbler/actions/runs/5134999446/jobs/9239806294

```
Run ansible-lint
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.3/x64/bin/ansible-lint", line 5, in <module>
    from ansiblelint.__main__ import _run_cli_entrypoint
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/ansiblelint/__main__.py", line 39, in <module>
    from ansiblelint import cli
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/ansiblelint/cli.py", line 29, in <module>
    from ansiblelint.yaml_utils import clean_json
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/ansiblelint/yaml_utils.py", line 31, in <module>
    from ansiblelint.utils import Task
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/ansiblelint/utils.py", line 56, in <module>
    from ansiblelint.app import get_app
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/ansiblelint/app.py", line 1[7](https://github.com/mila-iqia/ansible-role-cobbler/actions/runs/5134999446/jobs/9239806294#step:5:8), in <module>
    from ansiblelint.color import console, console_stderr, render_yaml
  File "/opt/hostedtoolcache/Python/3.[11](https://github.com/mila-iqia/ansible-role-cobbler/actions/runs/5134999446/jobs/9239806294#step:5:12).3/x64/lib/python3.11/site-packages/ansiblelint/color.py", line 7, in <module>
    import rich.markdown
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/rich/markdown.py", line 7, in <module>
    from typing_extensions import get_args
ModuleNotFoundError: No module named 'typing_extensions'
Error: Process completed with exit code 1.
```