### PR TITLE
fix: remove any snippet if no snippets are managed

### DIFF
--- a/tasks/snippets.yml
+++ b/tasks/snippets.yml
@@ -47,4 +47,4 @@
         path: "{{ item }}"
         state: absent
       loop: "{{ _existing_snippets }}"
-      when: item not in _managed_snippets
+      when: _managed_snippets is not defined or item not in _managed_snippets

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ passenv =
 deps =
     ansible6: ansible>=6.0,<7.0
     ansible7: ansible>=7.0,<8.0
-    ansible-lint<6.17.0
     molecule
     molecule-plugins[docker]
 commands =


### PR DESCRIPTION
When the last snippet of a `_snippet_type` is removed from the
inventory, make sure that the snippet file will be removed from the
Cobbler configuration.

Fixes #24