### PR TITLE
remove 'to_nice_yaml' filter

### DIFF
--- a/templates/local.settings.j2
+++ b/templates/local.settings.j2
@@ -1,2 +1,2 @@
 # {{ ansible_managed }}
-{{ cobbler_settings | to_nice_yaml(indent=2) }}
+{{ cobbler_settings }}

--- a/templates/local.settings.j2
+++ b/templates/local.settings.j2
@@ -1,2 +1,2 @@
 # {{ ansible_managed }}
-{{ cobbler_settings }}
+{{ cobbler_settings | to_json(vault_to_text=True) | from_json | to_nice_yaml }}


### PR DESCRIPTION
'to_nice_yaml' don't decrypt vaulted vars and copy the vaulted string as-is. removing this filter decrypt the var as intended.