### PR TITLE
remove 'when is defined' in main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ cobbler_autoinstall_templates: []
 cobbler_settings:
 
 # Cobbler distros (OS)
+cobbler_distros: []
 # cobbler_distros:
 #   - name: distro_name
 #     netboot: # Information about netboot files initrd and kernel
@@ -66,6 +67,7 @@ cobbler_settings:
 #       kernel: /var/lib/tftpboot/debian/11.2/debian-installer/amd64/linux
 
 # Cobbler profiles
+cobbler_profiles: []
 # cobbler_profiles:
 #   - name: profile_name
 #     properties: # Dict of Cobbler properties, as defined in the plugin cobbler_profile
@@ -75,6 +77,9 @@ cobbler_settings:
 #       - name: partition
 #         content: |
 #           any content to put in $SNIPPET('partition')
+
+# Cobbler systems
+cobbler_systems: []
 
 ## Dnsmasq
 # To use Dnsmasq as DHCP and DNS servers managed by Cobbler, enable this

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,14 +71,11 @@
 - name: Configure distros
   ansible.builtin.include_tasks:
     file: "distros.yml"
-  when: cobbler_distros is defined
 
 - name: Configure profiles
   ansible.builtin.include_tasks:
     file: "profiles.yml"
-  when: cobbler_profiles is defined
 
 - name: Configure systems
   ansible.builtin.include_tasks:
     file: "systems.yml"
-  when: cobbler_systems is defined


### PR DESCRIPTION
remove conditions 'when is defined' for cobbler_distros, cobbler_profiles and cobbler_systems, to avoid silent failure.

You have to define 'cobbler_systems: []' to maintain the same behavior, but if, for any reason, you have an undefined var in cobbler_distros or cobbler_profiles, the task will not fail silently.