### PR TITLE
Update rhel.ks.j2 template for RHEL 8 and 9

### DIFF
--- a/templates/templates/rhel.ks.j2
+++ b/templates/templates/rhel.ks.j2
@@ -1,8 +1,7 @@
 # Sample kickstart file for current EL, Fedora based distributions.
+# https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html
 
 #platform=x86, AMD64, or Intel EM64T
-# System authorization information
-auth  --useshadow  --enablemd5
 # System bootloader configuration
 bootloader --location=mbr
 # Partition clearing information
@@ -34,8 +33,6 @@ selinux --disabled
 skipx
 # System timezone
 timezone  America/New_York
-# Install OS instead of upgrade
-install
 # Configure partitions
 $SNIPPET('partition')
 


### PR DESCRIPTION
- Remove 'install' (Install OS instead of upgrade) The install Kickstart command is obsolete in RHEL 8, and removed in RHEL 9, causing an error during installation of AlmaLinux 9.

- Remove 'auth  --useshadow  --enablemd5' (System authorization information) auth and authconfig Kickstart command are deprecated in RHEL 8. Passwords are shadowed by default (and use sha512)

- Breaking changes : These changes are probably incompatible with RHEL 7 (untested).

- Added link to official documentation