### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          path: btravouillon.cobbler
+          path: mila.cobbler
 
       - name: Setup python environment
         uses: actions/setup-python@v3
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run molecule test
         run: |
-          cd btravouillon.cobbler && tox
+          cd mila.cobbler && tox

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,7 +88,7 @@ cobbler_systems: []
 # cobbler_settings, otherwise Cobbler will not configure the services.
 cobbler_dnsmasq_module: false
 
-# cobbler_dnsmasq_options, a 'BlockInFile' inserted 'As is' in /etc/cobbler/dnsmasq.template 
+# cobbler_dnsmasq_options, a 'BlockInFile' inserted 'As is' in /etc/cobbler/dnsmasq.template
 # cobbler_dnsmasq_options: |
 #   interface=eth0
 #   dhcp-range=192.168.0.101,192.168.0.150

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: "2.12"
+  min_ansible_version: "2.15"
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,4 +8,4 @@
   tasks:
     - name: "Include cobbler"
       ansible.builtin.include_role:
-        name: "btravouillon.cobbler"
+        name: "mila.cobbler"

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,5 @@ deps =
     molecule
     molecule-plugins[docker]
 commands =
+    ansible-galaxy collection install community.docker==3.10.2
     molecule test

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ passenv =
 deps =
     ansible8: ansible>=8.0,<9.0
     ansible9: ansible>=9.0,<10.0
+    jmespath
     molecule
     molecule-plugins[docker]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = ansible{6,7}
+envlist = ansible{8,9}
 skipsdist = true
 
 [testenv]
@@ -11,8 +11,8 @@ passenv =
     PY_COLORS
     ANSIBLE_FORCE_COLOR
 deps =
-    ansible6: ansible>=6.0,<7.0
-    ansible7: ansible>=7.0,<8.0
+    ansible8: ansible>=8.0,<9.0
+    ansible9: ansible>=9.0,<10.0
     molecule
     molecule-plugins[docker]
 commands =


### PR DESCRIPTION
- Remove trailing space reported by ansible-lint
- Test latest Ansible 8 and 9 (6 and 7 are EOL)
- Update community.docker to latest 3.10.2 (not included in `ansible` yet)
- Use mila namespace with molecule instead of btravouillon
- Install jmespath dependency for json_query