### PR TITLE
Add cobbler_proxy_url to allow installation via a proxy.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@ cobbler_configure_repos: false
 # Cobbler GPG Key
 # cobbler_gpg_key: 'https://download.opensuse.org/repositories/systemsmanagement/CentOS_7/repodata/repomd.xml.key'
 
+# Define a proxy for the installation if necessary.
+# cobbler_proxy_url: http://192.168.0.100:3128
+
 # Credentials for the cobbler API
 cobbler_api_username: cobbler
 cobbler_api_password: CHANGEME

--- a/templates/templates/debian.seed.j2
+++ b/templates/templates/debian.seed.j2
@@ -36,7 +36,7 @@ $SNIPPET('netcfg')
 d-i mirror/country string manual
 d-i mirror/http/hostname string $install_source_hostname
 d-i mirror/http/directory string $install_source_directory
-d-i mirror/http/proxy string
+d-i mirror/http/proxy string {% if cobbler_proxy_url is defined %}{{ cobbler_proxy_url }}{% endif +%}
 
 # Suite to install.
 #d-i mirror/suite string testing

--- a/templates/templates/rhel.ks.j2
+++ b/templates/templates/rhel.ks.j2
@@ -17,7 +17,7 @@ keyboard us
 # System language
 lang en_US.UTF-8
 # Use network installation
-url --url=$tree
+url --url=$tree {% if cobbler_proxy_url is defined %}--proxy={{ cobbler_proxy_url }}{% endif +%}
 # If any cobbler repo definitions were referenced in the kickstart profile, include them here.
 $yum_repo_stanza
 # Network information


### PR DESCRIPTION
- add cobbler_proxy_url in defaults/main.yml
- update templates debian.seed.j2 & rhel.ks.j2 to use the new cobbler_proxy_url