### PR TITLE
fix: Update grub filename for UEFI in dnsmasq

### DIFF
--- a/tasks/modules.yml
+++ b/tasks/modules.yml
@@ -32,7 +32,7 @@
       loop:
         - "dhcp-vendorclass=UEFI,PXEClient:Arch:00007"
         - "dhcp-vendorclass=UEFI,PXEClient:Arch:00009"
-        - "dhcp-boot=net:UEFI,grub/grubx86.efi"
+        - "dhcp-boot=net:UEFI,grub/grubx64.efi"
       notify: Restart cobbler
 
     - name: Enable dnsmasq in modules


### PR DESCRIPTION
The file was renamed from grubx86.efi to grubx64.efi in Cobbler 3.3.6.

See cobbler/cobbler#3626.