### PR TITLE
fix: Disable StartLimitIntervalSec in dnsmasq

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -27,3 +27,8 @@
 
 - name: Run cobbler sync (would need a plugin)
   ansible.builtin.command: cobbler sync
+
+- name: Daemon-reload dnsmasq
+  ansible.builtin.systemd_service:
+    name: dnsmasq.service
+    daemon_reload: true

--- a/tasks/modules.yml
+++ b/tasks/modules.yml
@@ -7,6 +7,23 @@
         name:
           - dnsmasq
 
+    - name: Create dnsmasq.service.d drop-in directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/dnsmasq.service.d/
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Disable StartLimitIntervalSec in dnsmasq.service
+      ansible.builtin.copy:
+        content: "[Unit]\nStartLimitIntervalSec=0"
+        dest: /etc/systemd/system/dnsmasq.service.d/override.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Daemon-reload dnsmasq
+
     - name: Configure dhcp-range in dnsmasq.template
       ansible.builtin.lineinfile:
         path: /etc/cobbler/dnsmasq.template


### PR DESCRIPTION
Cobbler restarts dnsmasq.service every time a system is edited. With Ansible, system edit may happen at scale. Thus we need to make sure systemd will not prevent dnsmasq from restarting multiple times in a row.

Closes: #40